### PR TITLE
Make mirage-net-unix work with libuv

### DIFF
--- a/duniverse/ethernet/src/ethernet.mli
+++ b/duniverse/ethernet/src/ethernet.mli
@@ -83,21 +83,20 @@ module type S = sig
   (** [mtu eth] is the Maximum Transmission Unit of the [eth] i.e. the maximum
       size of the payload, excluding the ethernet frame header. *)
 
-  val input :
+  val read :
     arpv4:(Cstruct.t -> unit) ->
     ipv4:(Cstruct.t -> unit) ->
     ipv6:(Cstruct.t -> unit) ->
     t ->
-    Cstruct.t ->
     unit
   (** [input ~arpv4 ~ipv4 ~ipv6 eth buffer] decodes the buffer and demultiplexes
       it depending on the protocol to the callback. *)
 end
 
-module Make (N : Mirage_net.S) : sig
+module Impl : sig
   include S
 
-  val connect : N.t -> t
+  val connect : Mirage_net.t -> t
   (** [connect netif] connects an ethernet layer on top of the raw
       network device [netif]. *)
 end

--- a/duniverse/mirage-net-unix/src/dune
+++ b/duniverse/mirage-net-unix/src/dune
@@ -1,6 +1,6 @@
 (library
  (name mirage_net_unix)
  (public_name mirage-net-unix)
- (libraries logs macaddr cstruct eio eio_linux mirage-net tuntap)
+ (libraries logs macaddr cstruct eio eio.unix mirage-net tuntap)
  (modules netif)
  (wrapped false))

--- a/duniverse/mirage-net-unix/src/dune
+++ b/duniverse/mirage-net-unix/src/dune
@@ -2,5 +2,5 @@
  (name mirage_net_unix)
  (public_name mirage-net-unix)
  (libraries logs macaddr cstruct eio eio.unix mirage-net tuntap)
- (modules netif)
+ (modules netif region)
  (wrapped false))

--- a/duniverse/mirage-net-unix/src/dune
+++ b/duniverse/mirage-net-unix/src/dune
@@ -2,5 +2,5 @@
  (name mirage_net_unix)
  (public_name mirage-net-unix)
  (libraries logs macaddr cstruct eio eio.unix mirage-net tuntap)
- (modules netif region)
+ (modules netif netif_region)
  (wrapped false))

--- a/duniverse/mirage-net-unix/src/netif.mli
+++ b/duniverse/mirage-net-unix/src/netif.mli
@@ -22,5 +22,5 @@ include Mirage_net.S
 val connect : sw:Eio.Std.Switch.t -> string -> t
 (** [connect tap] connects to the given tap interface. *)
 
-val fd : t -> Eio_linux.FD.t
+val fd : t -> Eio_unix.socket
 (** [fd t] is [t]'s underneath file descriptor. *)

--- a/duniverse/mirage-net-unix/src/netif.mli
+++ b/duniverse/mirage-net-unix/src/netif.mli
@@ -17,10 +17,5 @@
 
 (** Implementation of the network interface for Unix backends. *)
 
-include Mirage_net.S
-
-val connect : sw:Eio.Std.Switch.t -> string -> t
+val connect : sw:Eio.Std.Switch.t -> string -> Mirage_net.t
 (** [connect tap] connects to the given tap interface. *)
-
-val fd : t -> Eio_unix.socket
-(** [fd t] is [t]'s underneath file descriptor. *)

--- a/duniverse/mirage-net-unix/src/netif_region.ml
+++ b/duniverse/mirage-net-unix/src/netif_region.ml
@@ -1,0 +1,52 @@
+(* Carve up a region of contiguous memory for use
+ * by the uring IO stack *)
+
+(* TODO turn into a variable length slab allocator *)
+type t = {
+  buf: Cstruct.buffer;
+  block_size: int;
+  slots: int;
+  freelist: int Queue.t;
+}
+
+type chunk = t * int
+
+exception No_space
+
+let init ~block_size buf slots =
+  let freelist = Queue.create () in
+  for i = 0 to slots - 1 do
+    Queue.push (i*block_size) freelist
+  done;
+  { freelist; slots; block_size; buf }
+
+let alloc t =
+  match Queue.pop t.freelist with
+  | r -> t, r
+  | exception Queue.Empty -> raise No_space
+
+let free ({freelist; _}, v) =
+  Queue.push v freelist
+
+let length ({block_size;_}, _) = block_size
+
+let length_option t = function
+  | None -> t.block_size
+  | Some len ->
+    if len > t.block_size then
+      invalid_arg (Printf.sprintf "to_cstruct: requested length %d > block size %d" len t.block_size)
+    else
+      len
+
+let to_cstruct ?len (t, chunk) =
+  Cstruct.of_bigarray ~off:chunk ~len:(length_option t len) t.buf
+
+let to_bigstring ?len (t, chunk) =
+  Bigarray.Array1.sub t.buf chunk (length_option t len)
+
+let to_string ?len (t, chunk) =
+  Cstruct.to_string (to_cstruct ?len (t, chunk))
+
+let avail {freelist;_} = Queue.length freelist
+
+let to_offset (_,t) = t

--- a/duniverse/mirage-net-unix/src/netif_region.mli
+++ b/duniverse/mirage-net-unix/src/netif_region.mli
@@ -1,0 +1,58 @@
+(** [Region] handles carving up a block of external memory into
+    smaller chunks.  This is currently just a slab allocator of
+    a fixed size, on the basis that most IO operations operate on
+    predictable chunks of memory. Since the block of memory in a
+    region is contiguous, it can be used in Uring's fixed buffer
+    model to map it into kernel space for more efficient IO. *)
+
+type t
+(** [t] is a contiguous region of memory *)
+
+type chunk
+(** [chunk] is an offset into a region of memory allocated
+    from some region [t].  It is of a length set when the
+    region [t] associated with it was initialised. *)
+
+exception No_space
+(** [No_space] is raised when an allocation request cannot
+    be satisfied. *)
+
+val init: block_size:int -> Cstruct.buffer -> int -> t
+(** [init ~block_size buf slots] initialises a region from
+    the buffer [buf] with total size of [block_size * slots]. *)
+
+val alloc : t -> chunk
+(** [alloc t] will allocate a single chuck of length [block_size]
+    from the region [t]. *)
+
+val free : chunk -> unit
+(** [free chunk] will return the memory [chunk] back to the region
+    [t] where it can be reallocated. *)
+
+val length : chunk -> int
+(** [length chunk] is the block size. *)
+
+val to_offset : chunk -> int
+(** [to_offset chunk] will convert the [chunk] into an integer
+    offset in its associated region.  This can be used in IO calls
+    involving that memory. *)
+
+val to_cstruct : ?len:int -> chunk -> Cstruct.t
+(** [to_cstruct chunk] is a cstruct of [chunk]'s slice of the region.
+    Note that this is a zero-copy view into the underlying region [t]
+    and so [chunk] should not be freed until this cstruct is no longer used.
+    @param len Use only the first [len] bytes of [chunk]. *)
+
+val to_bigstring : ?len:int -> chunk -> Cstruct.buffer
+(** [to_bigstring] is like {!to_cstruct}, but creates a {!Bigarray}.
+    Note that this is a zero-copy view into the underlying region [t]
+    and so [chunk] should not be freed until this Bigarray reference is no longer used.
+    @param len Use only the first [len] bytes of [chunk]. *)
+
+val to_string : ?len:int -> chunk -> string
+(** [to_string ?len chunk] will return a copy of [chunk] as an OCaml string.
+    @param len Use only the first [len] bytes of [chunk]. *)
+
+val avail : t -> int
+(** [avail t] is the number of free chunks of memory remaining
+    in the region. *)

--- a/duniverse/mirage-net-unix/src/netif_region.mli
+++ b/duniverse/mirage-net-unix/src/netif_region.mli
@@ -25,6 +25,10 @@ val alloc : t -> chunk
 (** [alloc t] will allocate a single chuck of length [block_size]
     from the region [t]. *)
 
+val alloc_block : t -> chunk
+(** [alloc t] will allocate a single chuck of length [block_size]
+    from the region [t], or block until one is available. *)
+
 val free : chunk -> unit
 (** [free chunk] will return the memory [chunk] back to the region
     [t] where it can be reallocated. *)

--- a/duniverse/mirage-net/src/mirage_net.ml
+++ b/duniverse/mirage-net/src/mirage_net.ml
@@ -46,14 +46,10 @@ module Stats = struct
     t.tx_pkts <- 0l
 end
 
-module type S = sig
-  type t
-
-  val disconnect : t -> unit
-  val writev : t -> Cstruct.t list -> unit
-  val listen : t -> header_size:int -> (Cstruct.t -> unit) -> unit
-  val mac : t -> Macaddr.t
-  val mtu : t -> int
-  val get_stats_counters : t -> stats
-  val reset_stats_counters : t -> unit
-end
+type t = <
+  Eio.Flow.two_way;
+  mac : Macaddr.t;
+  mtu : int;
+  get_stats_counters : stats;
+  reset_stats_counters : unit;
+>

--- a/duniverse/mirage-net/src/mirage_net.mli
+++ b/duniverse/mirage-net/src/mirage_net.mli
@@ -37,46 +37,13 @@ type stats = {
 
 (** {2 Networking} *)
 
-(** A network interface that serves Ethernet frames. *)
-module type S = sig
-  type t
-  (** The type representing the internal state of the network device. *)
-
-  val disconnect : t -> unit
-  (** Disconnect from the network device. While this might take some time to
-      complete, it can never result in an error. *)
-
-  val writev : t -> Cstruct.t list -> unit
-  (** [write net ~size fill] allocates a buffer of length [size], where [size]
-     must not exceed the interface maximum packet size ({!mtu} plus Ethernet
-     header). The allocated buffer is zeroed and passed to the [fill] function
-     which returns the payload length, which may not exceed the length of the
-     buffer. When [fill] returns, a sub buffer is put on the wire: the allocated
-     buffer from index 0 to the returned length.
-     
-     Can raise Invalid_length *)
-
-  val listen : t -> header_size:int -> (Cstruct.t -> unit) -> unit
-  (** [listen ~header_size net fn] waits for a [packet] with size at most
-     [header_size + mtu] on the network device. When a [packet] is received, an
-     asynchronous task is created in which [fn packet] is called. The ownership
-     of [packet] is transferred to [fn].  The function can be stopped by calling
-     {!disconnect}. *)
-
-  val mac : t -> Macaddr.t
-  (** [mac net] is the MAC address of [net]. *)
-
-  val mtu : t -> int
-  (** [mtu net] is the Maximum Transmission Unit of [net]. This excludes the
-     Ethernet header. *)
-
-  val get_stats_counters : t -> stats
-  (** Obtain the most recent snapshot of the interface statistics. *)
-
-  val reset_stats_counters : t -> unit
-  (** Reset the statistics associated with this interface to their
-      defaults. *)
-end
+type t = <
+  Eio.Flow.two_way;
+  mac : Macaddr.t;
+  mtu : int;
+  get_stats_counters : stats;
+  reset_stats_counters : unit;
+>
 
 module Stats : sig
   val create : unit -> stats

--- a/duniverse/mirage-tcpip/src/ipv6/ipv6.mli
+++ b/duniverse/mirage-tcpip/src/ipv6/ipv6.mli
@@ -14,8 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-module Make (N : Mirage_net.S)
-            (E : Ethernet.S)
+module Make (E : Ethernet.S)
             (R : Mirage_random.S) : sig
   include Tcpip.Ip.S with type ipaddr = Ipaddr.V6.t
   val connect :
@@ -23,5 +22,5 @@ module Make (N : Mirage_net.S)
     ?handle_ra:bool ->
     ?cidr:Ndpv6.prefix ->
     ?gateway:ipaddr ->
-    clock:Eio.Time.clock -> sw:Eio.Switch.t -> N.t -> E.t -> t
+    clock:Eio.Time.clock -> sw:Eio.Switch.t -> Mirage_net.t -> E.t -> t
 end

--- a/duniverse/mirage-tcpip/src/stack-direct/tcpip_stack_direct.mli
+++ b/duniverse/mirage-tcpip/src/stack-direct/tcpip_stack_direct.mli
@@ -16,7 +16,6 @@
 
 module Make
     (Random   : Mirage_random.S)
-    (Netif    : Mirage_net.S)
     (Ethernet : Ethernet.S)
     (Arpv4    : Arp.S)
     (Ipv4     : Tcpip.Ip.S with type ipaddr = Ipaddr.V4.t)
@@ -28,7 +27,7 @@ module Make
      and module TCPV4 = Tcpv4
      and module UDPV4 = Udpv4
 
-  val connect : sw:Eio.Switch.t -> Netif.t -> Ethernet.t -> Arpv4.t -> Ipv4.t -> Icmpv4.t ->
+  val connect : sw:Eio.Switch.t -> Mirage_net.t -> Ethernet.t -> Arpv4.t -> Ipv4.t -> Icmpv4.t ->
     Udpv4.t -> Tcpv4.t -> t
   (** [connect] assembles the arguments into a network stack, then calls
       `listen` on the assembled stack before returning it to the caller.  The
@@ -39,7 +38,6 @@ end
 
 module MakeV6
     (Random   : Mirage_random.S)
-    (Netif    : Mirage_net.S)
     (Ethernet : Ethernet.S)
     (Ipv6     : Tcpip.Ip.S with type ipaddr = Ipaddr.V6.t)
     (Udpv6    : Tcpip.Udp.S with type ipaddr = Ipaddr.V6.t)
@@ -49,7 +47,7 @@ module MakeV6
      and module TCP = Tcpv6
      and module UDP = Udpv6
 
-  val connect : sw:Eio.Switch.t -> Netif.t -> Ethernet.t -> Ipv6.t -> Udpv6.t -> Tcpv6.t -> t
+  val connect : sw:Eio.Switch.t -> Mirage_net.t -> Ethernet.t -> Ipv6.t -> Udpv6.t -> Tcpv6.t -> t
   (** [connect] assembles the arguments into a network stack, then calls
       `listen` on the assembled stack before returning it to the caller.  The
       initial `listen` functions to ensure that the lower-level layers are
@@ -65,7 +63,6 @@ end
 
 module MakeV4V6
     (Random   : Mirage_random.S)
-    (Netif    : Mirage_net.S)
     (Ethernet : Ethernet.S)
     (Arpv4    : Arp.S)
     (Ip       : Tcpip.Ip.S with type ipaddr = Ipaddr.t)
@@ -77,7 +74,7 @@ module MakeV4V6
      and module TCP = Tcp
      and module UDP = Udp
 
-  val connect : sw:Eio.Switch.t -> Netif.t -> Ethernet.t -> Arpv4.t -> Ip.t -> Icmpv4.t -> Udp.t -> Tcp.t -> t
+  val connect : sw:Eio.Switch.t -> Mirage_net.t -> Ethernet.t -> Arpv4.t -> Ip.t -> Icmpv4.t -> Udp.t -> Tcp.t -> t
   (** [connect] assembles the arguments into a network stack, then calls
       `listen` on the assembled stack before returning it to the caller.  The
       initial `listen` functions to ensure that the lower-level layers are

--- a/duniverse/ocaml-tuntap/lib/tuntap_stubs.c
+++ b/duniverse/ocaml-tuntap/lib/tuntap_stubs.c
@@ -58,7 +58,7 @@ tun_alloc(char *dev, int kind, int pi, int persist, int user, int group)
   struct ifreq ifr;
   int fd;
 
-  if ((fd = open("/dev/net/tun", O_RDWR | O_NONBLOCK)) == -1)
+  if ((fd = open("/dev/net/tun", O_RDWR)) == -1)
     tun_raise_error("open", -1);
 
   memset(&ifr, 0, sizeof(ifr));

--- a/example/dune
+++ b/example/dune
@@ -24,4 +24,5 @@
   mirage-net-unix
   mirage-clock-unix
   mirage-random-test
+  logs.fmt
   eio_main))


### PR DESCRIPTION
It uses `Eio_unix` as suggested by @haesbaert, and now all the examples should build on MacOS.

I have also attempted to defuntorize parts of the stack by implementing netif as an eio flow, basically replacing module types by objects, I'm not sure if there's a benefit. Also maybe that netif is more akin to a datagram socket than a flow. 

In another branch (https://github.com/TheLortex/mirage-monorepo/tree/defuntor-ethernet), I push the attempt further but I probably got something wrong at it killed the performances (8req/s instead of 10k!!!)